### PR TITLE
Add tests for locking functionality

### DIFF
--- a/tests/locking.html
+++ b/tests/locking.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<script src="resources/text-encode-transform.js"></script>
+<script src="resources/transform-stream.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+const string = 'I \u{1F499} streams';
+const bytes = [73, 32, 240, 159, 146, 153, 32, 115, 116, 114, 101,
+                             97, 109, 115];
+const bytesAsArray = new Uint8Array(bytes);
+
+test(() => {
+  const encoder = new TextEncoder();
+  const writer = encoder.writable.getWriter();
+  assert_throws(new TypeError(), () => encoder.encode(string),
+                'encode should throw');
+  writer.releaseLock();
+  assert_array_equals(encoder.encode(string), bytes, 'encode should not throw');
+}, 'locking TextEncoder writable should prevent encode()');
+
+test(() => {
+  const encoder = new TextEncoder();
+  const reader = encoder.readable.getReader();
+  assert_throws(new TypeError(), () => encoder.encode(string),
+                'encode should throw');
+  reader.releaseLock();
+  assert_array_equals(encoder.encode(string), bytes, 'encode should not throw');
+}, 'locking TextEncoder readable should prevent encode()');
+
+test(() => {
+  const decoder = new TextDecoder();
+  const writer = decoder.writable.getWriter();
+  assert_throws(new TypeError(), () => decoder.decode(bytesAsArray),
+                'decode should throw');
+  writer.releaseLock();
+  assert_equals(decoder.decode(bytesAsArray), string,
+                'decode should not throw');
+}, 'locking TextDecoder writable should prevent decode()');
+
+test(() => {
+  const decoder = new TextDecoder();
+  const reader = decoder.readable.getReader();
+  assert_throws(new TypeError(), () => decoder.decode(bytesAsArray),
+                'decode should throw');
+  reader.releaseLock();
+  assert_equals(decoder.decode(bytesAsArray), string,
+                'decode should not throw');
+}, 'locking TextDecoder readable should prevent decode()');
+
+</script>


### PR DESCRIPTION
Ensure that decode() and encode() methods throw exceptions when one of the
readable or writable sides is locked.