### PR TITLE
Do nothing if already implemented

### DIFF
--- a/text-encode-transform.js
+++ b/text-encode-transform.js
@@ -17,6 +17,13 @@
 (function() {
   'use strict';
 
+  if (TextEncoder.prototype.readable !== undefined &&
+      TextEncoder.prototype.writable !== undefined &&
+      TextDecoder.prototype.readable !== undefined &&
+      TextDecoder.prototype.writable !== undefined) {
+    return;
+  }
+
   const real = {
     TextEncoder: self.TextEncoder,
     TextDecoder: self.TextDecoder


### PR DESCRIPTION
If the polyfill finds itself executing in an environment where
TextEncoder and TextDecoder already implement the readable and writable
interfaces, it should do nothing. Make it so.