### PR TITLE
Modify prototypes instead of wrapping

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -134,7 +134,7 @@ None known.
  - A previous implementation wrapped the existing TextEncoder and TextDecoder
    APIs. This was considerably simpler and easier to understand, but was
    inefficient.
- - For strict compliance the `readable` and `writable` getters should verify
+ - For strict compliance, the `readable` and `writable` getters should verify
    that `this` is of the correct type before attaching a TransformStream to
    it. However, in the context of a polyfill this would interfere with
    extensibility and so the check is intentionally omitted.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,5 +1,5 @@
 # Text Encoder Streaming Prollyfill
-ricea@chromium.org - last updated 3 March 2017
+ricea@chromium.org - last updated 16 November 2017
 
 The TextEncoder and TextDecoder APIs provide conversions between bytes and
 strings for Javascript in the browser. The Streams API is an API for processing
@@ -61,6 +61,22 @@ The prollyfill builds upon [The Web
 Platform](http://tess.oconnor.cx/2009/05/what-the-web-platform-is) and is
 implemented in [Javascript](http://www.ecma-international.org/ecma-262/6.0/).
 
+### Implementation
+
+The prototypes of the existing TextEncoder and TextDecoder classes are modified
+to add the extra functionality. `readable` and `writable` getters are added to
+the prototype. These work by delegating to a
+[TransformStream](https://streams.spec.whatwg.org/#ts) object, which is lazily
+created the first time they are accessed. The TransformStream is stored as a
+symbol property on the object, to avoid interfering with the usable namespace.
+
+The `encode()` and `decode()` methods are wrapped to verify that the readable
+and writable sides aren't locked before proceeding with the operation.
+
+`encode`, `decode` and the `readable` and `writable` getters are all defined as
+functions of the appropriate names, so that the `name` property on the function
+objects will be correct.
+
 ### Scalability
 
 The time taken to transform text to bytes and vice-versa is proportional to the
@@ -115,6 +131,12 @@ None known.
 
  - Supporting ES5 would have been possible, but would have made the code harder
    to understand.
- - This implementation wraps the existing TextEncoder and TextDecoder APIs. It
-   would be possible to monkey-patch them in place instead, but it would be more
-   complex.
+ - A previous implementation wrapped the existing TextEncoder and TextDecoder
+   APIs. This was considerably simpler and easier to understand, but was
+   inefficient.
+ - For strict compliance the `readable` and `writable` getters should verify
+   that `this` is of the correct type before attaching a TransformStream to
+   it. However, in the context of a polyfill this would interfere with
+   extensibility and so the check is intentionally omitted.
+ - Similarly, no attempt is made to defend against changes to the global object
+   made by other code on the same page.

--- a/tests/stream-properties.html
+++ b/tests/stream-properties.html
@@ -6,13 +6,23 @@
 <script>
 'use strict';
 
+function assertGetterConfiguredCorrectly(prototype, name) {
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+  assert_true(descriptor.configurable, 'getter must be configurable');
+  assert_true(descriptor.enumerable, 'getter must be enumerable');
+  assert_not_equals(descriptor.get, undefined, 'get must be defined');
+  assert_equals(descriptor.set, undefined, 'set must be undefined');
+}
+
 test(() => {
   const te = new TextEncoder();
   assert_inherits(te, 'readable', 'readable property must be present');
+  assertGetterConfiguredCorrectly(TextEncoder.prototype, 'readable');
   assert_readonly(te, 'readable', 'readable property must be read-only');
   assert_equals(typeof ReadableStream.prototype.getReader.call(te.readable),
                 'object', 'readable property must pass brand check');
   assert_inherits(te, 'writable', 'writable property must be present');
+  assertGetterConfiguredCorrectly(TextEncoder.prototype, 'writable');
   assert_readonly(te, 'writable', 'writable property must be read-only');
   assert_equals(typeof WritableStream.prototype.getWriter.call(te.writable),
                 'object', 'writable property must pass brand check');
@@ -21,10 +31,12 @@ test(() => {
 test(() => {
   const td = new TextDecoder();
   assert_inherits(td, 'readable', 'readable property must be present');
+  assertGetterConfiguredCorrectly(TextDecoder.prototype, 'readable');
   assert_readonly(td, 'readable', 'readable property must be read-only');
   assert_equals(typeof ReadableStream.prototype.getReader.call(td.readable),
                 'object', 'readable property must pass brand check');
   assert_inherits(td, 'writable', 'writable property must be present');
+  assertGetterConfiguredCorrectly(TextDecoder.prototype, 'writable');
   assert_readonly(td, 'writable', 'writable property must be read-only');
   assert_equals(typeof WritableStream.prototype.getWriter.call(td.writable),
                 'object', 'writable property must pass brand check');

--- a/text-encode-transform.js
+++ b/text-encode-transform.js
@@ -85,7 +85,6 @@
                           {
                             configurable: true,
                             enumerable: true,
-                            configurable: true,
                             get: readable
                           });
 
@@ -93,7 +92,6 @@
                           {
                             configurable: true,
                             enumerable: true,
-                            configurable: true,
                             get: writable
                           });
   }


### PR DESCRIPTION
Previously the polyfill wrapped TextEncoder and TextDecoder with
replacement implementations. This was simple but inefficient. Instead,
modify the prototypes of the original objects to reduce the size and
overhead of the polyfill.

Also update the design document to add detail about how the
implementation works, and note that the implementation has changed.

Also modify the stream-properties.html test to verify that readable and
writable accessors are enumerable. This was not the case with the
wrapping implementation, which was non-conformant with WebIDL.