### PR TITLE
Fix the check for a native implementation

### DIFF
--- a/text-encode-transform.js
+++ b/text-encode-transform.js
@@ -25,10 +25,10 @@
     throw new ReferenceError('TextDecoder implementation required');
   }
 
-  if (self.TextEncoder.prototype.readable !== undefined &&
-      self.TextEncoder.prototype.writable !== undefined &&
-      self.TextDecoder.prototype.readable !== undefined &&
-      self.TextDecoder.prototype.writable !== undefined) {
+  if ('readable' in self.TextEncoder.prototype &&
+      'writable' in self.TextEncoder.prototype &&
+      'readable' in self.TextDecoder.prototype &&
+      'writable' in self.TextDecoder.prototype) {
     return;
   }
 


### PR DESCRIPTION
The old check for a native implementation would throw an exception if
the native implementation included a brand check on the "readable" and
"writable" accessors. Modify the check to not actually read from the
accessors.

Fixes #7.