### PR TITLE
Fix string conversion in TextEncoder transform()

### DIFF
--- a/text-encode-transform.js
+++ b/text-encode-transform.js
@@ -111,6 +111,7 @@
     }
 
     transform(chunk, controller) {
+      chunk = String(chunk);
       if (this._carry !== undefined) {
         chunk = this._carry + chunk;
         this._carry = undefined;


### PR DESCRIPTION
The addition of handling for unpaired surrogates broke the implicit
conversion of non-strings to strings. Add an explicit conversion to fix
it.