### PR TITLE
Add tests that objects are created in correct realms

### DIFF
--- a/tests/realms.html
+++ b/tests/realms.html
@@ -20,9 +20,10 @@ setup({explicit_done: true});
 
 function createRealm() {
   let iframe = document.createElement('iframe');
+  const scriptEndTag = '<' + '/script>';
   iframe.srcdoc = `<!doctype html>
-<script src="resources/text-encode-transform.js">${'<'}/script>
-<script src="resources/transform-stream.js">${'<'}/script>
+<script src="resources/text-encode-transform.js">${scriptEndTag}
+<script src="resources/transform-stream.js">${scriptEndTag}
 <script>
 onmessage = event => {
   if (event.source !== window.parent) {
@@ -149,7 +150,7 @@ window.onload = () => {
 function runGenericTests(classname) {
   promise_test(async () => {
     const obj = await evalInRealmAndReturn(
-      constructedRealm, `new parent.constructorRealm.${classname}()`);
+        constructedRealm, `new parent.constructorRealm.${classname}()`);
     assert_equals(obj.constructor, constructorRealm[classname],
                   'obj should be in constructor realm');
   }, `a ${classname} object should be associated with the realm the ` +
@@ -175,7 +176,7 @@ function runGenericTests(classname) {
     assert_equals(writable.constructor, methodRealm.WritableStream,
                   'writable should be in method realm');
   }, `${classname}\'s readable and writable attributes should come from the ` +
-      'same realm as the method definition');
+     'same realm as the method definition');
 }
 
 function runTextEncoderTests() {
@@ -253,8 +254,8 @@ function runTextDecoderTests() {
     assert_equals(result.constructor, constructorRealm.Object,
                   'result should be in constructor realm');
     // Strings are always in the current realm, so no point in checking.
-   }, 'the result object when write is called with a pending ' +
-      'read should come from the same realm as the constructor of TextDecoder');
+  }, 'the result object when write is called with a pending ' +
+     'read should come from the same realm as the constructor of TextDecoder');
 
   promise_test(async t => {
     const objId = await constructAndStore('TextDecoder');

--- a/tests/realms.html
+++ b/tests/realms.html
@@ -108,7 +108,7 @@ async function evalInRealmAndReturn(realm, code) {
   return realm[myId];
 }
 
-// Construct an object in constructedRealm and copy it into readRealm and
+// Constructs an object in constructedRealm and copies it into readRealm and
 // writeRealm. Returns the id that can be used to access the object in those
 // realms. |what| can contain constructor arguments.
 async function constructAndStore(what) {
@@ -175,7 +175,7 @@ function runGenericTests(classname) {
                   'readable should be in method realm');
     assert_equals(writable.constructor, methodRealm.WritableStream,
                   'writable should be in method realm');
-  }, `${classname}\'s readable and writable attributes should come from the ` +
+  }, `${classname}'s readable and writable attributes should come from the ` +
      'same realm as the method definition');
 }
 
@@ -241,7 +241,8 @@ function runTextDecoderTests() {
     await writePromise;
     assert_equals(result.constructor, constructorRealm.Object,
                   'result should be in constructor realm');
-    // Strings are always in the current realm, so no point in checking.
+    // All strings have the same prototype object, regardless of which frame
+    // created them. So checking the realm of result.value is not meaningful.
   }, 'the result object when read is called after write should come from the ' +
      'same realm as the constructor of TextDecoder');
 
@@ -253,7 +254,8 @@ function runTextDecoderTests() {
     const result = await chunkPromise;
     assert_equals(result.constructor, constructorRealm.Object,
                   'result should be in constructor realm');
-    // Strings are always in the current realm, so no point in checking.
+    // All strings have the same prototype object, regardless of which frame
+    // created them. So checking the realm of result.value is not meaningful.
   }, 'the result object when write is called with a pending ' +
      'read should come from the same realm as the constructor of TextDecoder');
 
@@ -279,7 +281,7 @@ function runTextDecoderTests() {
       assert_equals(err.constructor, constructorRealm.TypeError,
                     'read TypeError should come from constructor realm');
     }
-  }, 'TypeError for chunk if the wrong type should come from constructor ' +
+  }, 'TypeError for chunk with the wrong type should come from constructor ' +
      'realm of TextDecoder');
 
   promise_test(async t => {
@@ -287,8 +289,6 @@ function runTextDecoderTests() {
           await constructAndStore(`TextDecoder('utf-8', {fatal: true})`);
     // Read first to relieve backpressure.
     const readPromise = readInReadRealm(objId);
-    // Write an invalid chunk.
-    const invalidBytesId = id();
     // promise_rejects() does not permit directly inspecting the rejection, so
     // it's necessary to write it out long-hand.
     try {

--- a/tests/realms.html
+++ b/tests/realms.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<script src="resources/text-encode-transform.js"></script>
+<script src="resources/transform-stream.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+'use strict';
+
+// Test that objects created by the streaming TextEncoder and TextDecoder APIs
+// are created in the correct realm. The tests work by creating an iframe for
+// each realm and then posting Javascript to them to be evaluated. Inputs and
+// outputs are passed around via global variables in each realm's scope.
+
+// Some of these tests do not pass with the TransformStream polyfill. They work
+// correctly with a conformant implementation.
+
+// Async setup is required before creating any tests, so require done() to be
+// called.
+setup({explicit_done: true});
+
+function createRealm() {
+  let iframe = document.createElement('iframe');
+  iframe.srcdoc = `<!doctype html>
+<script src="resources/text-encode-transform.js">${'<'}/script>
+<script src="resources/transform-stream.js">${'<'}/script>
+<script>
+onmessage = event => {
+  if (event.source !== window.parent) {
+    return;
+  }
+  eval(event.data);
+};
+${'<'}/script>`;
+  iframe.style.display = 'none';
+  document.body.appendChild(iframe);
+  let realmPromiseResolve;
+  const realmPromise = new Promise(resolve => {
+    realmPromiseResolve = resolve;
+  });
+  iframe.onload = () => {
+    realmPromiseResolve(iframe.contentWindow);
+  };
+  return realmPromise;
+}
+
+async function createRealms() {
+  // All realms are visible on the global object so they can access each other.
+
+  // The realm that the constructor function comes from.
+  window.constructorRealm = await createRealm();
+
+  // The realm in which the constructor object is called.
+  window.constructedRealm = await createRealm();
+
+  // The realm in which reading happens.
+  window.readRealm = await createRealm();
+
+  // The realm in which writing happens.
+  window.writeRealm = await createRealm();
+
+  // The realm that provides the definitions of Readable and Writable methods.
+  window.methodRealm = await createRealm();
+
+  await evalInRealmAndWait(methodRealm, `
+  window.ReadableStreamDefaultReader =
+      new ReadableStream().getReader().constructor;
+  window.WritableStreamDefaultWriter =
+      new WritableStream().getWriter().constructor;
+`);
+  window.readMethod = methodRealm.ReadableStreamDefaultReader.prototype.read;
+  window.writeMethod = methodRealm.WritableStreamDefaultWriter.prototype.write;
+}
+
+// In order for values to be visible between realms, they need to be
+// global. To prevent interference between tests, variable names are generated
+// automatically.
+const id = (() => {
+  let nextId = 0;
+  return () => {
+    return `realmsId${nextId++}`;
+  };
+})();
+
+// Eval string "code" in the content of realm "realm". Evaluation happens
+// asynchronously, meaning it hasn't happened when the function returns.
+function evalInRealm(realm, code) {
+  realm.postMessage(code, window.origin);
+}
+
+// Same as evalInRealm() but returns a Promise which will resolve when the
+// function has actually.
+async function evalInRealmAndWait(realm, code) {
+  const resolve = id();
+  const waitOn = new Promise(r => {
+    realm[resolve] = r;
+  });
+  evalInRealm(realm, code);
+  evalInRealm(realm, `${resolve}();`);
+  await waitOn;
+}
+
+// The same as evalInRealmAndWait but returns the result of evaluating "code" as
+// an expression.
+async function evalInRealmAndReturn(realm, code) {
+  const myId = id();
+  await evalInRealmAndWait(realm, `window.${myId} = ${code};`);
+  return realm[myId];
+}
+
+// Construct an object in constructedRealm and copy it into readRealm and
+// writeRealm. Returns the id that can be used to access the object in those
+// realms. |what| can contain constructor arguments.
+async function constructAndStore(what) {
+  const objId = id();
+  writeRealm[objId] = await evalInRealmAndReturn(
+      constructedRealm, `new parent.constructorRealm.${what}`);
+  readRealm[objId] = writeRealm[objId];
+  return objId;
+}
+
+// Calls read() on the readable side of the TransformStream stored in
+// readRealm[objId]. Locks the readable side as a side-effect.
+function readInReadRealm(objId) {
+  return evalInRealmAndReturn(readRealm, `
+parent.readMethod.call(window.${objId}.readable.getReader())`);
+}
+
+// Calls write() on the writable side of the TransformStream stored in
+// writeRealm[objId], passing |value|. Locks the writable side as a
+// side-effect.
+function writeInWriteRealm(objId, value) {
+  const valueId = id();
+  writeRealm[valueId] = value;
+  return evalInRealmAndReturn(writeRealm, `
+parent.writeMethod.call(window.${objId}.writable.getWriter(),
+                        window.${valueId})`);
+}
+
+window.onload = () => {
+  createRealms().then(() => {
+    runGenericTests('TextEncoder');
+    runTextEncoderTests();
+    runGenericTests('TextDecoder');
+    runTextDecoderTests();
+    done();
+  });
+};
+
+function runGenericTests(classname) {
+  promise_test(async () => {
+    const obj = await evalInRealmAndReturn(
+      constructedRealm, `new parent.constructorRealm.${classname}()`);
+    assert_equals(obj.constructor, constructorRealm[classname],
+                  'obj should be in constructor realm');
+  }, `a ${classname} object should be associated with the realm the ` +
+     'constructor came from');
+
+  promise_test(async () => {
+    const objId = await constructAndStore(classname);
+    const readableGetterId = id();
+    readRealm[readableGetterId] = Object.getOwnPropertyDescriptor(
+        methodRealm[classname].prototype, 'readable').get;
+    const writableGetterId = id();
+    writeRealm[writableGetterId] = Object.getOwnPropertyDescriptor(
+        methodRealm[classname].prototype, 'writable').get;
+    const readable = await evalInRealmAndReturn(
+        readRealm, `${readableGetterId}.call(${objId})`);
+    const writable = await evalInRealmAndReturn(
+        writeRealm, `${writableGetterId}.call(${objId})`);
+    // TODO(ricea): These expectations match what the polyfill does but should
+    // be changed to "constructorRealm" when this test is upstreamed, as that is
+    // the correct behaviour by the standard.
+    assert_equals(readable.constructor, methodRealm.ReadableStream,
+                  'readable should be in method realm');
+    assert_equals(writable.constructor, methodRealm.WritableStream,
+                  'writable should be in method realm');
+  }, `${classname}\'s readable and writable attributes should come from the ` +
+      'same realm as the method definition');
+}
+
+function runTextEncoderTests() {
+  promise_test(async () => {
+    const objId = await constructAndStore('TextEncoder');
+    const writePromise = writeInWriteRealm(objId, 'A');
+    const result = await readInReadRealm(objId);
+    await writePromise;
+    assert_equals(result.constructor, constructorRealm.Object,
+                  'result should be in constructor realm');
+    assert_equals(result.value.constructor, constructorRealm.Uint8Array,
+                  'chunk should be in constructor realm');
+  }, 'the output chunks when read is called after write should come from the ' +
+     'same realm as the constructor of TextEncoder');
+
+  promise_test(async () => {
+    const objId = await constructAndStore('TextEncoder');
+    const chunkPromise = readInReadRealm(objId);
+    writeInWriteRealm(objId, 'A');
+    // Now the read() should resolve.
+    const result = await chunkPromise;
+    assert_equals(result.constructor, constructorRealm.Object,
+                  'result should be in constructor realm');
+    assert_equals(result.value.constructor, constructorRealm.Uint8Array,
+                  'chunk should be in constructor realm');
+  }, 'the output chunks when write is called with a pending read should come ' +
+     'from the same realm as the constructor of TextEncoder');
+
+  promise_test(async t => {
+    const objId = await constructAndStore('TextEncoder');
+    // Read first to relieve backpressure.
+    const readPromise = readInReadRealm(objId);
+    // promise_rejects() does not permit directly inspecting the rejection, so
+    // it's necessary to write it out long-hand.
+    try {
+      // Write an invalid chunk.
+      await writeInWriteRealm(objId, {
+        toString() { return {}; }
+      });
+      assert_unreached('write should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'write TypeError should come from constructor realm');
+    }
+
+    try {
+      await readPromise;
+      assert_unreached('read should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'read TypeError should come from constructor realm');
+    }
+  }, 'TypeError for unconvertable chunk should come from constructor realm ' +
+     'of TextEncoder');
+}
+
+function runTextDecoderTests() {
+  promise_test(async () => {
+    const objId = await constructAndStore('TextDecoder');
+    const writePromise = writeInWriteRealm(objId, new Uint8Array([65]));
+    const result = await readInReadRealm(objId);
+    await writePromise;
+    assert_equals(result.constructor, constructorRealm.Object,
+                  'result should be in constructor realm');
+    // Strings are always in the current realm, so no point in checking.
+  }, 'the result object when read is called after write should come from the ' +
+     'same realm as the constructor of TextDecoder');
+
+  promise_test(async () => {
+    const objId = await constructAndStore('TextDecoder');
+    const chunkPromise = readInReadRealm(objId);
+    writeInWriteRealm(objId, new Uint8Array([65]));
+    // Now the read() should resolve.
+    const result = await chunkPromise;
+    assert_equals(result.constructor, constructorRealm.Object,
+                  'result should be in constructor realm');
+    // Strings are always in the current realm, so no point in checking.
+   }, 'the result object when write is called with a pending ' +
+      'read should come from the same realm as the constructor of TextDecoder');
+
+  promise_test(async t => {
+    const objId = await constructAndStore('TextDecoder');
+    // Read first to relieve backpressure.
+    const readPromise = readInReadRealm(objId);
+    // promise_rejects() does not permit directly inspecting the rejection, so
+    // it's necessary to write it out long-hand.
+    try {
+      // Write an invalid chunk.
+      await writeInWriteRealm(objId, {});
+      assert_unreached('write should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'write TypeError should come from constructor realm');
+    }
+
+    try {
+      await readPromise;
+      assert_unreached('read should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'read TypeError should come from constructor realm');
+    }
+  }, 'TypeError for chunk if the wrong type should come from constructor ' +
+     'realm of TextDecoder');
+
+  promise_test(async t => {
+    const objId =
+          await constructAndStore(`TextDecoder('utf-8', {fatal: true})`);
+    // Read first to relieve backpressure.
+    const readPromise = readInReadRealm(objId);
+    // Write an invalid chunk.
+    const invalidBytesId = id();
+    // promise_rejects() does not permit directly inspecting the rejection, so
+    // it's necessary to write it out long-hand.
+    try {
+      await writeInWriteRealm(objId, new Uint8Array([0xff]));
+      assert_unreached('write should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'write TypeError should come from constructor realm');
+    }
+
+    try {
+      await readPromise;
+      assert_unreached('read should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'read TypeError should come from constructor realm');
+    }
+  }, 'TypeError for invalid chunk should come from constructor realm ' +
+     'of TextDecoder');
+
+  promise_test(async t => {
+    const objId =
+          await constructAndStore(`TextDecoder('utf-8', {fatal: true})`);
+    // Read first to relieve backpressure.
+    readInReadRealm(objId);
+    // Write an unfinished sequence of bytes.
+    const incompleteBytesId = id();
+    writeRealm[incompleteBytesId] = new Uint8Array([0xf0]);
+    // promise_rejects() does not permit directly inspecting the rejection, so
+    // it's necessary to write it out long-hand.
+    try {
+      // Can't use writeInWriteRealm() here because it doesn't make it possible
+      // to reuse the writer.
+      await evalInRealmAndReturn(writeRealm, `
+(() => {
+  const writer = window.${objId}.writable.getWriter();
+  parent.writeMethod.call(writer, window.${incompleteBytesId});
+  return parent.methodRealm.WritableStreamDefaultWriter.prototype
+    .close.call(writer);
+})();
+`);
+      assert_unreached('close should fail');
+    } catch (err) {
+      assert_equals(err.constructor, constructorRealm.TypeError,
+                    'close TypeError should come from constructor realm');
+    }
+  }, 'TypeError for incomplete input should come from constructor realm ' +
+     'of TextDecoder');
+}
+
+</script>


### PR DESCRIPTION
When Javascript in multiple iframes interacts it becomes important to
distinguish which objects belong to which realm. Add tests that verify
that objects emitted by TextEncoder and TextDecoder streams were created
in the correct realm.