### PR TITLE
Don't override native implementation

### DIFF
--- a/text-encode-transform.js
+++ b/text-encode-transform.js
@@ -17,6 +17,12 @@
 (function() {
   'use strict';
 
+  if (typeof self.TextEncoderStream === 'function' &&
+      typeof self.TextDecoderStream === 'function') {
+    // The constructors exist. Assume that they work and don't replace them.
+    return;
+  }
+
   if (typeof self.TextEncoder !== 'function') {
     throw new ReferenceError('TextEncoder implementation required');
   }


### PR DESCRIPTION
If there is a native implementation of TextEncoderStream and
TextDecoderStream, don't replace it.